### PR TITLE
[Feature] PDF export functionality for yearly reports

### DIFF
--- a/RentTracker/Resources/Base.lproj/Localizable.strings
+++ b/RentTracker/Resources/Base.lproj/Localizable.strings
@@ -1,0 +1,40 @@
+/* Notification actions */
+"Mark Paid" = "Mark Paid";
+"Remind Later" = "Remind Later";
+"Contact Tenant" = "Contact Tenant";
+
+/* Notification titles */
+"Rent Due" = "Rent Due";
+"Payment Overdue" = "Payment Overdue";
+"Rent Reminder" = "Rent Reminder";
+
+/* Payment types */
+"Rent" = "Rent";
+"Late Fee" = "Late Fee";
+"Deposit" = "Deposit";
+"Deposit Return" = "Deposit Return";
+
+/* Property types */
+"Residential" = "Residential";
+"Commercial" = "Commercial";
+
+/* Payment cycles */
+"Monthly" = "Monthly";
+"Bi-monthly" = "Bi-monthly";
+"Quarterly" = "Quarterly";
+"Yearly" = "Yearly";
+
+/* Contract status */
+"Active" = "Active";
+"Expiring Soon" = "Expiring Soon";
+"Expired" = "Expired";
+"Ended" = "Ended";
+"Upcoming" = "Upcoming";
+
+/* Payment status */
+"Paid" = "Paid";
+"Overdue" = "Overdue";
+"Due Soon" = "Due Soon";
+"Upcoming" = "Upcoming";
+
+

--- a/RentTracker/Resources/zh-Hans.lproj/Localizable.strings
+++ b/RentTracker/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,40 @@
+/* 通知操作 */
+"Mark Paid" = "标记已支付";
+"Remind Later" = "稍后提醒";
+"Contact Tenant" = "联系租客";
+
+/* 通知标题 */
+"Rent Due" = "房租到期";
+"Payment Overdue" = "付款逾期";
+"Rent Reminder" = "房租提醒";
+
+/* 收款类型 */
+"Rent" = "房租";
+"Late Fee" = "滞纳金";
+"Deposit" = "押金";
+"Deposit Return" = "退还押金";
+
+/* 房屋类型 */
+"Residential" = "住宅";
+"Commercial" = "商业";
+
+/* 支付周期 */
+"Monthly" = "每月";
+"Bi-monthly" = "每两月";
+"Quarterly" = "每季度";
+"Yearly" = "每年";
+
+/* 合同状态 */
+"Active" = "进行中";
+"Expiring Soon" = "即将到期";
+"Expired" = "已到期";
+"Ended" = "已结束";
+"Upcoming" = "未开始";
+
+/* 付款状态 */
+"Paid" = "已支付";
+"Overdue" = "逾期";
+"Due Soon" = "即将到期";
+"Upcoming" = "即将到来";
+
+

--- a/RentTracker/Resources/zh-Hant.lproj/Localizable.strings
+++ b/RentTracker/Resources/zh-Hant.lproj/Localizable.strings
@@ -1,0 +1,40 @@
+/* 通知操作 */
+"Mark Paid" = "標記已支付";
+"Remind Later" = "稍後提醒";
+"Contact Tenant" = "聯絡房客";
+
+/* 通知標題 */
+"Rent Due" = "房租到期";
+"Payment Overdue" = "付款逾期";
+"Rent Reminder" = "房租提醒";
+
+/* 收款類型 */
+"Rent" = "房租";
+"Late Fee" = "滯納金";
+"Deposit" = "押金";
+"Deposit Return" = "退還押金";
+
+/* 房屋類型 */
+"Residential" = "住宅";
+"Commercial" = "商業";
+
+/* 支付週期 */
+"Monthly" = "每月";
+"Bi-monthly" = "每兩月";
+"Quarterly" = "每季";
+"Yearly" = "每年";
+
+/* 合同狀態 */
+"Active" = "進行中";
+"Expiring Soon" = "即將到期";
+"Expired" = "已到期";
+"Ended" = "已結束";
+"Upcoming" = "未開始";
+
+/* 付款狀態 */
+"Paid" = "已支付";
+"Overdue" = "逾期";
+"Due Soon" = "即將到期";
+"Upcoming" = "即將到來";
+
+

--- a/RentTracker/Services/CoreDataService.swift
+++ b/RentTracker/Services/CoreDataService.swift
@@ -34,8 +34,11 @@ class CoreDataService {
 
     func calculateYearlyIncome(year: Int) -> Decimal {
         let calendar = Calendar.current
-        let startDate = calendar.date(from: DateComponents(year: year, month: 1, day: 1))!
-        let endDate = calendar.date(from: DateComponents(year: year + 1, month: 1, day: 1))!
+        guard let startDate = calendar.date(from: DateComponents(year: year, month: 1, day: 1)),
+              let endDate = calendar.date(from: DateComponents(year: year + 1, month: 1, day: 1)) else {
+            print("Failed to create date range for year \(year)")
+            return Decimal.zero
+        }
 
         let request: NSFetchRequest<Payment> = Payment.fetchRequest()
         request.predicate = NSPredicate(format: "paymentDate >= %@ AND paymentDate < %@ AND paymentType.name LIKE 'Rent'",
@@ -54,8 +57,11 @@ class CoreDataService {
 
     func calculateYearlyExpenses(year: Int) -> Decimal {
         let calendar = Calendar.current
-        let startDate = calendar.date(from: DateComponents(year: year, month: 1, day: 1))!
-        let endDate = calendar.date(from: DateComponents(year: year + 1, month: 1, day: 1))!
+        guard let startDate = calendar.date(from: DateComponents(year: year, month: 1, day: 1)),
+              let endDate = calendar.date(from: DateComponents(year: year + 1, month: 1, day: 1)) else {
+            print("Failed to create date range for year \(year)")
+            return Decimal.zero
+        }
 
         let request: NSFetchRequest<Expense> = Expense.fetchRequest()
         request.predicate = NSPredicate(format: "expenseDate >= %@ AND expenseDate < %@",

--- a/RentTracker/Services/CoreDataService.swift
+++ b/RentTracker/Services/CoreDataService.swift
@@ -1,0 +1,74 @@
+import Foundation
+import CoreData
+
+class CoreDataService {
+    static let shared = CoreDataService()
+
+    private init() {}
+
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: "RentTracker")
+        container.loadPersistentStores { _, error in
+            if let error = error {
+                fatalError("Core Data failed to load: \(error.localizedDescription)")
+            }
+        }
+        return container
+    }()
+
+    var context: NSManagedObjectContext {
+        return persistentContainer.viewContext
+    }
+
+    func save() {
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                print("Failed to save context: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    // MARK: - Yearly Income/Expense Calculations
+
+    func calculateYearlyIncome(year: Int) -> Decimal {
+        let calendar = Calendar.current
+        let startDate = calendar.date(from: DateComponents(year: year, month: 1, day: 1))!
+        let endDate = calendar.date(from: DateComponents(year: year + 1, month: 1, day: 1))!
+
+        let request: NSFetchRequest<Payment> = Payment.fetchRequest()
+        request.predicate = NSPredicate(format: "paymentDate >= %@ AND paymentDate < %@ AND paymentType.name LIKE 'Rent'",
+                                       startDate as NSDate, endDate as NSDate)
+
+        do {
+            let payments = try context.fetch(request)
+            return payments.reduce(Decimal.zero) { result, payment in
+                result + (payment.amount?.decimalValue ?? 0)
+            }
+        } catch {
+            print("Failed to fetch yearly income: \(error.localizedDescription)")
+            return Decimal.zero
+        }
+    }
+
+    func calculateYearlyExpenses(year: Int) -> Decimal {
+        let calendar = Calendar.current
+        let startDate = calendar.date(from: DateComponents(year: year, month: 1, day: 1))!
+        let endDate = calendar.date(from: DateComponents(year: year + 1, month: 1, day: 1))!
+
+        let request: NSFetchRequest<Expense> = Expense.fetchRequest()
+        request.predicate = NSPredicate(format: "expenseDate >= %@ AND expenseDate < %@",
+                                       startDate as NSDate, endDate as NSDate)
+
+        do {
+            let expenses = try context.fetch(request)
+            return expenses.reduce(Decimal.zero) { result, expense in
+                result + (expense.amount?.decimalValue ?? 0)
+            }
+        } catch {
+            print("Failed to fetch yearly expenses: \(error.localizedDescription)")
+            return Decimal.zero
+        }
+    }
+}

--- a/RentTracker/Services/PDFExportService.swift
+++ b/RentTracker/Services/PDFExportService.swift
@@ -1,0 +1,67 @@
+import Foundation
+import PDFKit
+import SwiftUI
+
+class PDFExportService {
+    static let shared = PDFExportService()
+    private init() {}
+
+    func generateYearlyReport(year: Int) -> PDFDocument {
+        let pdf = PDFDocument()
+        let page = PDFPage(image: renderYearlyReportImage(year: year))
+        if let page = page {
+            pdf.insert(page, at: 0)
+        }
+        return pdf
+    }
+
+    func exportToTemporaryURL(_ document: PDFDocument, filename: String) -> URL? {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent("\(filename).pdf")
+        guard let data = document.dataRepresentation() else { return nil }
+        do {
+            try data.write(to: tmp, options: .atomic)
+            return tmp
+        } catch {
+            print("Failed to write PDF: \(error)")
+            return nil
+        }
+    }
+
+    private func renderYearlyReportImage(year: Int) -> UIImage {
+        let size = CGSize(width: 612, height: 792) // US Letter
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let image = renderer.image { ctx in
+            UIColor.white.setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+
+            let title = "Yearly Report - \(year)"
+            let attrs: [NSAttributedString.Key: Any] = [
+                .font: UIFont.boldSystemFont(ofSize: 24)
+            ]
+            title.draw(at: CGPoint(x: 48, y: 48), withAttributes: attrs)
+
+            let income = CoreDataService.shared.calculateYearlyIncome(year: year)
+            let expenses = CoreDataService.shared.calculateYearlyExpenses(year: year)
+            let net = income - expenses
+
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .currency
+            formatter.currencySymbol = "¥"
+
+            let lines = [
+                "Total Income: \(formatter.string(from: income as NSDecimalNumber) ?? "-")",
+                "Total Expenses: \(formatter.string(from: expenses as NSDecimalNumber) ?? "-")",
+                "Net Income: \(formatter.string(from: net as NSDecimalNumber) ?? "-")"
+            ]
+
+            var y: CGFloat = 120
+            for line in lines {
+                (line as NSString).draw(at: CGPoint(x: 48, y: y), withAttributes: [.font: UIFont.systemFont(ofSize: 16)])
+                y += 28
+            }
+        }
+        return image
+    }
+}
+
+

--- a/RentTracker/Views/Reports/ReportsTabView.swift
+++ b/RentTracker/Views/Reports/ReportsTabView.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+import UIKit
+
+struct ReportsTabView: View {
+    @EnvironmentObject var propertyViewModel: PropertyViewModel
+    @EnvironmentObject var paymentViewModel: PaymentViewModel
+    @State private var selectedYear = Calendar.current.component(.year, from: Date())
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 16) {
+                    yearSelectionSection
+                    summarySection
+                    exportOptionsSection
+                    Spacer(minLength: 32)
+                }
+                .padding()
+            }
+            .navigationTitle("Reports")
+        }
+    }
+
+    private var yearSelectionSection: some View {
+        VStack(spacing: 12) {
+            Text("Select Year")
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Picker("Year", selection: $selectedYear) {
+                ForEach(2020...2030, id: \.self) { year in
+                    Text("\(year)").tag(year)
+                }
+            }
+            .pickerStyle(WheelPickerStyle())
+            .frame(height: 100)
+        }
+    }
+
+    private var summarySection: some View {
+        VStack(spacing: 12) {
+            Text("Year \(selectedYear) Summary")
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(spacing: 8) {
+                HStack {
+                    Text("Total Income:")
+                        .font(.body)
+                    Spacer()
+                    Text("¥\(CoreDataService.shared.calculateYearlyIncome(year: selectedYear), specifier: "%.2f")")
+                        .font(.body.bold())
+                        .foregroundColor(.green)
+                }
+
+                HStack {
+                    Text("Total Expenses:")
+                        .font(.body)
+                    Spacer()
+                    Text("¥\(CoreDataService.shared.calculateYearlyExpenses(year: selectedYear), specifier: "%.2f")")
+                        .font(.body.bold())
+                        .foregroundColor(.red)
+                }
+
+                Divider()
+
+                HStack {
+                    Text("Net Income:")
+                        .font(.body.bold())
+                    Spacer()
+                    let netIncome = CoreDataService.shared.calculateYearlyIncome(year: selectedYear) - CoreDataService.shared.calculateYearlyExpenses(year: selectedYear)
+                    Text("¥\(netIncome, specifier: "%.2f")")
+                        .font(.body.bold())
+                        .foregroundColor(netIncome >= 0 ? .green : .red)
+                }
+            }
+            .padding()
+            .background(Color.gray.opacity(0.1))
+            .cornerRadius(8)
+        }
+    }
+
+    private var exportOptionsSection: some View {
+        VStack(spacing: 12) {
+            Text("Export Options")
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button(action: exportYearlyReport) {
+                HStack {
+                    Image(systemName: "doc.text")
+                    Text("Export Yearly Report (PDF)")
+                }
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color.blue)
+                .foregroundColor(.white)
+                .cornerRadius(8)
+            }
+        }
+    }
+
+    private func exportYearlyReport() {
+        let pdf = PDFExportService.shared.generateYearlyReport(year: selectedYear)
+        if let url = PDFExportService.shared.exportToTemporaryURL(pdf, filename: "Yearly_Report_\(selectedYear)") {
+            presentShareSheet(url)
+        }
+    }
+}
+
+extension ReportsTabView {
+    private func presentShareSheet(_ url: URL) {
+        guard let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let root = scene.windows.first?.rootViewController else { return }
+        let vc = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        root.present(vc, animated: true)
+    }
+}
+
+#Preview {
+    ReportsTabView()
+        .environmentObject(PropertyViewModel())
+        .environmentObject(PaymentViewModel())
+}


### PR DESCRIPTION
## Summary

- Adds PDF export capability for yearly financial reports
- Provides users with professional report generation and sharing functionality

## Changes

- New `PDFExportService` class with yearly report generation using PDFKit
- New `ReportsTabView` with year selection picker and export functionality  
- Integration with iOS share sheet for PDF distribution
- Currency formatting support with ¥ symbol for Chinese market

## Screenshots / Videos (if UI)

| Before | After |
|--------|-------|
| No reports functionality | Reports tab with year selection and PDF export |

## How to test

- Run the app and navigate to Reports tab
- Select a year from the picker
- Tap "Export Yearly Report (PDF)" button
- Verify share sheet appears with PDF attachment
- Test with different years to ensure data calculation works

## Checklist

- [x] Code builds locally
- [x] Tests added/updated (n/a - integration testing pending)
- [x] Lint passes
- [x] Docs updated (n/a)
- [x] No sensitive data committed

## Breaking changes

- [x] No

## Rollout / Risk

- Rollout plan: Merge after code review approval
- Risk level: Low
- Mitigations / rollback plan: Feature is additive, can revert PR if issues arise

🤖 Generated with [Claude Code](https://claude.ai/code)